### PR TITLE
test: kill gpg-agent in teardown to stop process leak

### DIFF
--- a/test/encrypt_decrypt.bats
+++ b/test/encrypt_decrypt.bats
@@ -79,8 +79,7 @@ setup() {
 
   # Create Bob in a separate keyring and encrypt to him
   local bob_home
-  bob_home=$(mktemp -d)
-  chmod 700 "$bob_home"
+  bob_home=$(setup_extra_gpg_home)
   GNUPGHOME="$bob_home" gpg --batch --pinentry-mode loopback --passphrase '' \
     --quick-gen-key "Bob <bob@example.com>" default default never 2>/dev/null
   ciphertext=$(echo "for bob only" | GNUPGHOME="$bob_home" gpg --batch --armor --trust-model always \

--- a/test/inspect.bats
+++ b/test/inspect.bats
@@ -52,8 +52,7 @@ setup() {
 
 @test "inspect shows no secret for public-only key" {
   local other_home
-  other_home=$(mktemp -d)
-  chmod 700 "$other_home"
+  other_home=$(setup_extra_gpg_home)
   GNUPGHOME="$other_home" gpg --batch --pinentry-mode loopback --passphrase '' \
     --quick-gen-key "External <ext@example.com>" default default never 2>/dev/null
   GNUPGHOME="$other_home" gpg --batch --armor --export "ext@example.com" \

--- a/test/list.bats
+++ b/test/list.bats
@@ -134,8 +134,7 @@ setup() {
   generate_test_key "Alice" "alice@example.com"
   # Import a public-only key
   local other_home
-  other_home=$(mktemp -d)
-  chmod 700 "$other_home"
+  other_home=$(setup_extra_gpg_home)
   GNUPGHOME="$other_home" gpg --batch --pinentry-mode loopback --passphrase '' \
     --quick-gen-key "External <ext@example.com>" default default never 2>/dev/null
   GNUPGHOME="$other_home" gpg --batch --armor --export "ext@example.com" \
@@ -150,8 +149,7 @@ setup() {
 @test "list --public shows only keys without private key" {
   generate_test_key "Alice" "alice@example.com"
   local other_home
-  other_home=$(mktemp -d)
-  chmod 700 "$other_home"
+  other_home=$(setup_extra_gpg_home)
   GNUPGHOME="$other_home" gpg --batch --pinentry-mode loopback --passphrase '' \
     --quick-gen-key "External <ext@example.com>" default default never 2>/dev/null
   GNUPGHOME="$other_home" gpg --batch --armor --export "ext@example.com" \

--- a/test/query.bats
+++ b/test/query.bats
@@ -127,8 +127,7 @@ setup() {
 
 @test "has_secret_key returns false for public-only key" {
   local other_home
-  other_home=$(mktemp -d)
-  chmod 700 "$other_home"
+  other_home=$(setup_extra_gpg_home)
   GNUPGHOME="$other_home" gpg --batch --pinentry-mode loopback --passphrase '' \
     --quick-gen-key "External <ext@example.com>" default default never 2>/dev/null
   GNUPGHOME="$other_home" gpg --batch --armor --export "ext@example.com" \

--- a/test/remove.bats
+++ b/test/remove.bats
@@ -8,8 +8,7 @@ setup() {
 @test "remove deletes a public-only key" {
   # Create a key in a separate home and import just the public part
   local other_home
-  other_home=$(mktemp -d)
-  chmod 700 "$other_home"
+  other_home=$(setup_extra_gpg_home)
   GNUPGHOME="$other_home" gpg --batch --pinentry-mode loopback --passphrase '' \
     --quick-gen-key "External <ext@example.com>" default default never 2>/dev/null
   GNUPGHOME="$other_home" gpg --batch --armor --export "ext@example.com" \

--- a/test/sign_verify.bats
+++ b/test/sign_verify.bats
@@ -54,8 +54,7 @@ setup() {
 @test "sign fails when key has no secret key" {
   # Import a public-only key
   local other_home
-  other_home=$(mktemp -d)
-  chmod 700 "$other_home"
+  other_home=$(setup_extra_gpg_home)
   GNUPGHOME="$other_home" gpg --batch --pinentry-mode loopback --passphrase '' \
     --quick-gen-key "External <ext@example.com>" default default never 2>/dev/null
   GNUPGHOME="$other_home" gpg --batch --armor --export "ext@example.com" \

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -21,9 +21,16 @@ setup_gpg_home() {
 # fds/process limits and subsequent runs hang waiting for an agent to bind a
 # socket — the "hangs partway through" flakiness.
 #
-# Called automatically by BATS after each test that loads this helper.
-# Individual .bats files can override teardown() if they need custom behavior,
-# but should call teardown_gpg_home themselves in that case.
+# ⚠️  If you define your own teardown() in a .bats file, BATS will call YOUR
+# version INSTEAD of the one below — silently skipping agent cleanup and
+# re-introducing the process leak this PR fixed. If you need a custom
+# teardown, call teardown_gpg_home and teardown_extra_gpg_homes from it:
+#
+#   teardown() {
+#     ...your custom logic...
+#     teardown_gpg_home
+#     teardown_extra_gpg_homes
+#   }
 teardown_gpg_home() {
   if [ -n "${GNUPGHOME:-}" ] && [ -d "$GNUPGHOME" ]; then
     gpgconf --homedir "$GNUPGHOME" --kill all 2>/dev/null || true
@@ -44,6 +51,10 @@ teardown_gpg_home() {
 # via `home=$(setup_extra_gpg_home)`, which runs in a subshell — a var set
 # there wouldn't survive back to teardown().
 setup_extra_gpg_home() {
+  [ -n "${BATS_TEST_TMPDIR:-}" ] || {
+    echo "setup_extra_gpg_home: BATS_TEST_TMPDIR unset — called outside a BATS test?" >&2
+    return 1
+  }
   local home
   home=$(mktemp -d)
   chmod 700 "$home"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -13,6 +13,27 @@ setup_gpg_home() {
   chmod 700 "$GNUPGHOME"
 }
 
+# Kill any gpg-agent/dirmngr spawned into this test's GNUPGHOME.
+#
+# gpg auto-spawns a gpg-agent daemon in $GNUPGHOME on first use. If we let BATS
+# wipe $BATS_TEST_TMPDIR with the agent still running, we leak a zombie daemon
+# (socket gone, process still alive) for every test. Under load that exhausts
+# fds/process limits and subsequent runs hang waiting for an agent to bind a
+# socket — the "hangs partway through" flakiness.
+#
+# Called automatically by BATS after each test that loads this helper.
+# Individual .bats files can override teardown() if they need custom behavior,
+# but should call teardown_gpg_home themselves in that case.
+teardown_gpg_home() {
+  if [ -n "${GNUPGHOME:-}" ] && [ -d "$GNUPGHOME" ]; then
+    gpgconf --homedir "$GNUPGHOME" --kill all 2>/dev/null || true
+  fi
+}
+
+teardown() {
+  teardown_gpg_home
+}
+
 # Generate a test key (no passphrase, no interaction)
 generate_test_key() {
   local name="${1:-Test User}"

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -30,8 +30,43 @@ teardown_gpg_home() {
   fi
 }
 
+# Create an additional isolated GPG home and register it for agent+dir cleanup
+# in teardown. Prints the path on stdout. Use this instead of a bare
+# `mktemp -d` when a test needs a second keyring — otherwise the gpg-agent
+# spawned there leaks (homedir isn't under $BATS_TEST_TMPDIR, so BATS doesn't
+# wipe it, and nothing kills the daemon).
+#
+# Uses mktemp rather than a path under $BATS_TEST_TMPDIR because the BATS
+# tmpdir is already ~70 chars deep, and gpg-agent's AF_UNIX socket path is
+# capped at 104 chars on macOS — anything longer makes gpg-agent fail to bind.
+#
+# Tracks registered homes in a file (not a shell var) because callers use this
+# via `home=$(setup_extra_gpg_home)`, which runs in a subshell — a var set
+# there wouldn't survive back to teardown().
+setup_extra_gpg_home() {
+  local home
+  home=$(mktemp -d)
+  chmod 700 "$home"
+  echo "$home" >> "$BATS_TEST_TMPDIR/.extra-gpg-homes"
+  echo "$home"
+}
+
+# Kill gpg-agents and remove every home registered via setup_extra_gpg_home.
+teardown_extra_gpg_homes() {
+  local registry="$BATS_TEST_TMPDIR/.extra-gpg-homes"
+  [ -f "$registry" ] || return 0
+  local h
+  while IFS= read -r h; do
+    [ -n "$h" ] || continue
+    gpgconf --homedir "$h" --kill all 2>/dev/null || true
+    rm -rf "$h" 2>/dev/null || true
+  done < "$registry"
+  rm -f "$registry"
+}
+
 teardown() {
   teardown_gpg_home
+  teardown_extra_gpg_homes
 }
 
 # Generate a test key (no passphrase, no interaction)

--- a/test/test_helper.bats
+++ b/test/test_helper.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+#
+# Tests for test_helper.bash itself — specifically teardown_gpg_home, which
+# prevents gpg-agent process leaks between tests. See commit for context.
+
+setup() {
+  load test_helper
+  setup_gpg_home
+}
+
+# Find the gpg-agent PID for a given GNUPGHOME, or empty if none.
+agent_pid_for() {
+  pgrep -f "gpg-agent --homedir $1" | head -n1
+}
+
+# Wait for a PID to exit (up to ~1s).
+wait_gone() {
+  local pid="$1"
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    kill -0 "$pid" 2>/dev/null || return 0
+    sleep 0.1
+  done
+  return 1
+}
+
+@test "teardown_gpg_home is a no-op when GNUPGHOME is unset" {
+  unset GNUPGHOME
+  run teardown_gpg_home
+  [ "$status" -eq 0 ]
+}
+
+@test "teardown_gpg_home is a no-op when GNUPGHOME dir does not exist" {
+  export GNUPGHOME="$BATS_TEST_TMPDIR/does-not-exist"
+  run teardown_gpg_home
+  [ "$status" -eq 0 ]
+}
+
+@test "teardown_gpg_home kills gpg-agent spawned in GNUPGHOME" {
+  # generate_test_key reliably spawns an agent (same path real tests take).
+  generate_test_key "Teardown Test" "teardown@example.com" >/dev/null
+  pid=$(agent_pid_for "$GNUPGHOME")
+  [ -n "$pid" ]
+  kill -0 "$pid"
+
+  teardown_gpg_home
+
+  wait_gone "$pid"
+}
+

--- a/test/test_helper.bats
+++ b/test/test_helper.bats
@@ -10,6 +10,7 @@ setup() {
 
 # Find the gpg-agent PID for a given GNUPGHOME, or empty if none.
 agent_pid_for() {
+  [ -n "${1:-}" ] || return 1
   pgrep -f "gpg-agent --homedir $1" | head -n1
 }
 
@@ -42,6 +43,8 @@ wait_gone() {
   [ -n "$pid" ]
   kill -0 "$pid"
 
+  # teardown() will call teardown_gpg_home again after this — harmless
+  # (gpgconf --kill on a dead agent is a no-op).
   teardown_gpg_home
 
   wait_gone "$pid"

--- a/test/test_helper.bats
+++ b/test/test_helper.bats
@@ -47,3 +47,25 @@ wait_gone() {
   wait_gone "$pid"
 }
 
+@test "setup_extra_gpg_home registers the home for teardown (survives subshell)" {
+  # Typical caller pattern: extra=$(setup_extra_gpg_home). The assignment
+  # happens in a subshell, so variable-based registration would be lost —
+  # test_helper uses a file-backed registry to survive this.
+  local extra
+  extra=$(setup_extra_gpg_home)
+  [ -d "$extra" ]
+  grep -qxF "$extra" "$BATS_TEST_TMPDIR/.extra-gpg-homes"
+
+  # Spawn an agent in the extra home.
+  GNUPGHOME="$extra" gpg --batch --pinentry-mode loopback --passphrase '' \
+    --quick-gen-key "Extra <extra@example.com>" default default never 2>/dev/null
+  pid=$(agent_pid_for "$extra")
+  [ -n "$pid" ]
+
+  teardown_extra_gpg_homes
+
+  wait_gone "$pid"
+  [ ! -d "$extra" ]
+  [ ! -f "$BATS_TEST_TMPDIR/.extra-gpg-homes" ]
+}
+


### PR DESCRIPTION
## Problem

Every `mise run test` was leaking **~75 gpg-agent processes** per run. After 5 runs on my box: 374 orphaned agents.

Each test that calls `setup_gpg_home` ends up spawning a gpg-agent daemon in its per-test $GNUPGHOME on first gpg use, and there was no teardown to kill it. Additionally, 7 tests that exercise cross-keyring behavior created a *second* GNUPGHOME via bare `mktemp -d`, with no cleanup at all — those dirs sit outside $BATS_TEST_TMPDIR so BATS never wiped them either.

This is almost certainly the root cause of the "mise run test hangs partway through" flakiness noted in earlier sessions. Under process/fd pressure, `gpg --quick-gen-key` waits on an agent socket that can't bind.

## Fix

**test_helper.bash:**
- `teardown_gpg_home()` — runs `gpgconf --homedir $GNUPGHOME --kill all`.
- `setup_extra_gpg_home()` — new helper for creating a *second* GPG home; registers it in a file-backed registry (`$BATS_TEST_TMPDIR/.extra-gpg-homes`). File-backed, not a shell variable, because the canonical caller pattern `home=$(setup_extra_gpg_home)` runs in a subshell — a var set there wouldn't reach teardown().
- `teardown_extra_gpg_homes()` — kills every registered agent and `rm -rf`s the home.
- Default `teardown()` in the helper runs both. All 12 existing bats files `load test_helper` in `setup()` and none define their own teardown, so they pick it up for free.

**test/*.bats:**
- Replaced all 7 `mktemp -d; chmod 700` pairs with `$(setup_extra_gpg_home)`.

**test/test_helper.bats (new):** four assertions
- `teardown_gpg_home` is a no-op on unset GNUPGHOME and on a missing dir.
- `teardown_gpg_home` kills the agent in $GNUPGHOME.
- `setup_extra_gpg_home` registers survives the subshell and teardown_extra_gpg_homes kills + rm -rfs.

## Verification

| | Leaked agents/run | Tests |
|--|--|--|
| Before | ~75 | 124 pass |
| After (first fix, v1) | ~7 | 127 pass |
| After (full fix, this PR) | **0** | **128 pass** |

Confirmed over multiple back-to-back runs on macOS. Full suite runs in ~90s (unchanged).

## Notes

- Kept `mktemp -d` (not $BATS_TEST_TMPDIR) for the extra home path: BATS tmpdirs are already ~70 chars deep, and gpg-agent's AF_UNIX socket path is capped at 104 on macOS — anything longer makes gpg-agent fail to bind.