### PR TITLE
test: lint .bats files for teardown() override without helpers

### DIFF
--- a/test/teardown_lint.bats
+++ b/test/teardown_lint.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# Lint — catches .bats files that override teardown() without calling the
+# gpg-agent cleanup helpers from test_helper.bash.
+#
+# Background: PR #2 centralized gpg-agent cleanup in a default teardown()
+# in test_helper.bash. BATS lets a file's own teardown() shadow the helper's,
+# which silently re-introduces the agent leak. This test fails CI if any
+# .bats file defines teardown() without calling both helpers.
+# See: https://github.com/KnickKnackLabs/testicles/issues/3
+
+# Returns 0 if all .bats files in $1 are clean; 1 otherwise (with offenders on stderr).
+lint_teardown_overrides() {
+  local dir=$1
+  local offenders=()
+  shopt -s nullglob
+  local f
+  for f in "$dir"/*.bats; do
+    grep -qE '^teardown\(\)' "$f" || continue
+    if ! grep -q 'teardown_gpg_home' "$f" || ! grep -q 'teardown_extra_gpg_homes' "$f"; then
+      offenders+=("$f")
+    fi
+  done
+  if [ "${#offenders[@]}" -gt 0 ]; then
+    local o
+    for o in "${offenders[@]}"; do
+      echo "$o overrides teardown() without calling teardown_gpg_home/teardown_extra_gpg_homes" >&2
+    done
+    return 1
+  fi
+}
+
+@test "no real .bats file overrides teardown() without helpers" {
+  run lint_teardown_overrides "$BATS_TEST_DIRNAME"
+  [ "$status" -eq 0 ]
+}
+
+@test "lint detects a .bats file that overrides teardown() without helpers" {
+  local tmp
+  tmp=$(mktemp -d)
+  cat > "$tmp/bad.bats" <<'BATS'
+#!/usr/bin/env bats
+teardown() {
+  echo "dangerous: no helper calls"
+}
+@test "noop" { :; }
+BATS
+  run lint_teardown_overrides "$tmp"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"bad.bats"* ]]
+  [[ "$output" == *"teardown_gpg_home"* ]]
+  rm -rf "$tmp"
+}
+
+@test "lint accepts a .bats file that overrides teardown() and calls both helpers" {
+  local tmp
+  tmp=$(mktemp -d)
+  cat > "$tmp/good.bats" <<'BATS'
+#!/usr/bin/env bats
+teardown() {
+  echo "cleaning up before helpers"
+  teardown_gpg_home
+  teardown_extra_gpg_homes
+}
+@test "noop" { :; }
+BATS
+  run lint_teardown_overrides "$tmp"
+  [ "$status" -eq 0 ]
+  rm -rf "$tmp"
+}
+
+@test "lint accepts a .bats file with no teardown() override at all" {
+  local tmp
+  tmp=$(mktemp -d)
+  cat > "$tmp/fine.bats" <<'BATS'
+#!/usr/bin/env bats
+@test "noop" { :; }
+BATS
+  run lint_teardown_overrides "$tmp"
+  [ "$status" -eq 0 ]
+  rm -rf "$tmp"
+}
+
+@test "lint flags a file calling only one of the two helpers" {
+  local tmp
+  tmp=$(mktemp -d)
+  cat > "$tmp/partial.bats" <<'BATS'
+#!/usr/bin/env bats
+teardown() {
+  teardown_gpg_home
+}
+@test "noop" { :; }
+BATS
+  run lint_teardown_overrides "$tmp"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"partial.bats"* ]]
+  rm -rf "$tmp"
+}


### PR DESCRIPTION
Closes #3.

## What

Adds `test/teardown_lint.bats` — a CI-time lint that fails if any `.bats` file defines its own `teardown()` without calling both `teardown_gpg_home` and `teardown_extra_gpg_homes`.

## Why

PR #2 centralized gpg-agent cleanup into the default `teardown()` in `test_helper.bash`. If a future `.bats` file defines its own `teardown()`, BATS calls that version *instead* of the helper's — silently skipping cleanup and re-introducing the agent leak. A prominent warning comment exists in the helper, but a CI lint catches what reviewers miss.

## Design

Single `lint_teardown_overrides` function (so behavior is single-sourced), exercised by 5 tests:

1. Real `test/*.bats` dir — passes today, guards the future.
2. Synthetic bad fixture (override, no helpers) — detected.
3. Synthetic good fixture (override calls both helpers) — accepted.
4. Synthetic fixture with no override at all — accepted.
5. Synthetic partial fixture (calls one helper) — detected.

## Verification

`mise run test` → 133/133 pass (was 128; +5 new).